### PR TITLE
Add dts declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Helper to use emmet modules in Visual Studio Code",
   "main": "./out/emmetHelper.js",
+  "types": "./out/emmetHelper.d.ts",
   "author": "Microsoft Corporation",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     "target": "es6",
     "lib": ["es2016"],
     "module": "commonjs",
-		"outDir": "out",
-		"declaration": true
+    "outDir": "out",
+    "declaration": true
   },
   "exclude": ["node_modules", "out"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,10 @@
 {
-	"compilerOptions": {
-		"target": "es6",
-		"lib": [
-			"es2016"
-		],
-		"module": "commonjs",
-		"outDir": "./out"
-
-	},
-	"exclude": [
-		"node_modules"
-	]
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["es2016"],
+    "module": "commonjs",
+		"outDir": "out",
+		"declaration": true
+  },
+  "exclude": ["node_modules", "out"]
 }


### PR DESCRIPTION
This adds dts declaration so when importing it we could have IntelliSense on the exported functions.

Still need to publish them to npm with `emmetHelper.d.ts` in `out` and this updated `package.json` though.