### PR TITLE
Adding vendor prefixes to css abbreviations

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -91,7 +91,7 @@ export function doComplete(document: TextDocument, position: Position, syntax: s
 	// If abbreviation is valid, then expand it and ensure the expanded value is not noise
 	if (isAbbreviationValid(syntax, abbreviation)) {
 		try {
-			expandedText = expandAbbreviationWithDash(abbreviation, expandOptions);
+			expandedText = expandCSSAbbreviationWithVendorPrefixes(abbreviation, expandOptions);
 		} catch (e) {
 		}
 
@@ -525,10 +525,10 @@ export function getExpandOptions(syntax: string, emmetConfig?: object, filter?: 
 	};
 }
 
-export function expandAbbreviationWithDash(abbreviation: string, options: any) {
+export function expandCSSAbbreviationWithVendorPrefixes(abbreviation: string, options: any) {
 	let expandedText;
 	let prefixes = ["-webkit-", "-moz-", "-ms-", "-o-"];
-	if (abbreviation[0] !== '-') {
+	if ( abbreviation[0] !== '-') {
 		expandedText = expand(abbreviation, options);
 	} else {
 		let tmp = expand(abbreviation.substr(1), options);
@@ -545,7 +545,7 @@ export function expandAbbreviationWithDash(abbreviation: string, options: any) {
  * @param options 
  */
 export function expandAbbreviation(abbreviation: string, options: any) {
-	let expandedText = expandAbbreviationWithDash(abbreviation, options);
+	let expandedText = isStyleSheet(options.syntax) ? expandCSSAbbreviationWithVendorPrefixes(abbreviation, options) : expand(abbreviation, options);
 	return escapeNonTabStopDollar(addFinalTabStop(expandedText));
 }
 

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -91,7 +91,7 @@ export function doComplete(document: TextDocument, position: Position, syntax: s
 	// If abbreviation is valid, then expand it and ensure the expanded value is not noise
 	if (isAbbreviationValid(syntax, abbreviation)) {
 		try {
-			expandedText = expandCSSAbbreviation(abbreviation, expandOptions);
+			expandedText = expandAbbreviationHelper(abbreviation, expandOptions);
 		} catch (e) {
 		}
 
@@ -525,18 +525,18 @@ export function getExpandOptions(syntax: string, emmetConfig?: object, filter?: 
 	};
 }
 
-function expandCSSAbbreviation(abbreviation: string, options: any) {
+function expandAbbreviationHelper(abbreviation: string, options: any) {
 	let expandedText;
 	let prefixes = ["-webkit-", "-moz-", "-ms-", "-o-"];
 	abbreviation = abbreviation || "";
-	if ( abbreviation[0] !== '-') {
-		expandedText = expand(abbreviation, options);
-	} else {
+	if (isStyleSheet(options.syntax) && abbreviation[0] == '-') {
 		let tmp = expand(abbreviation.substr(1), options);
 		expandedText = tmp;
 		for (let index = 0; index < prefixes.length; index++) {
 			expandedText += "\n" + prefixes[index] + tmp;
 		}
+	} else {
+		expandedText = expand(abbreviation, options);
 	}
 	return expandedText;
 }
@@ -546,7 +546,7 @@ function expandCSSAbbreviation(abbreviation: string, options: any) {
  * @param options 
  */
 export function expandAbbreviation(abbreviation: string, options: any) {
-	let expandedText = isStyleSheet(options.syntax) ? expandCSSAbbreviation(abbreviation, options) : expand(abbreviation, options);
+	let expandedText = expandAbbreviationHelper(abbreviation, options);
 	return escapeNonTabStopDollar(addFinalTabStop(expandedText));
 }
 

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -91,7 +91,7 @@ export function doComplete(document: TextDocument, position: Position, syntax: s
 	// If abbreviation is valid, then expand it and ensure the expanded value is not noise
 	if (isAbbreviationValid(syntax, abbreviation)) {
 		try {
-			expandedText = expandCSSAbbreviationWithVendorPrefixes(abbreviation, expandOptions);
+			expandedText = expandCSSAbbreviation(abbreviation, expandOptions);
 		} catch (e) {
 		}
 
@@ -525,9 +525,10 @@ export function getExpandOptions(syntax: string, emmetConfig?: object, filter?: 
 	};
 }
 
-export function expandCSSAbbreviationWithVendorPrefixes(abbreviation: string, options: any) {
+function expandCSSAbbreviation(abbreviation: string, options: any) {
 	let expandedText;
 	let prefixes = ["-webkit-", "-moz-", "-ms-", "-o-"];
+	abbreviation = abbreviation || "";
 	if ( abbreviation[0] !== '-') {
 		expandedText = expand(abbreviation, options);
 	} else {
@@ -545,7 +546,7 @@ export function expandCSSAbbreviationWithVendorPrefixes(abbreviation: string, op
  * @param options 
  */
 export function expandAbbreviation(abbreviation: string, options: any) {
-	let expandedText = isStyleSheet(options.syntax) ? expandCSSAbbreviationWithVendorPrefixes(abbreviation, options) : expand(abbreviation, options);
+	let expandedText = isStyleSheet(options.syntax) ? expandCSSAbbreviation(abbreviation, options) : expand(abbreviation, options);
 	return escapeNonTabStopDollar(addFinalTabStop(expandedText));
 }
 


### PR DESCRIPTION
Modified so that when preceding a CSS abbreviation with a dash, it gets expanded with all the vendor-prefixes.

For example, `-bdrd10` gets expanded to 
```
border-right: 10px;
-webkit-border-right 10px: 
-moz-border-right: 10px;
-ms-border-right: 10px;
-o-border-right: 10px;
```