### PR TITLE
Specify vendor prefixes

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -32,7 +32,8 @@ const defaultUnitAliases = {
 	p: '%',
 	x: 'ex',
 	r: 'rem'
-}
+};
+const vendorPrefixes = { 'w': "webkit", 'm': "moz", 's': "ms", 'o': "o" };
 
 export interface EmmetConfiguration {
 	showExpandedAbbreviation: string;
@@ -568,35 +569,37 @@ function splitVendorPrefix(abbreviation: string): { prefixOptions: string, abbre
 }
 
 function applyVendorPrefixes(expandedProperty: string, vendors: string, preferences: any) {
-	const vendorPrefixes = { 'w': "webkit", 'm': "moz", 's': "ms", 'o': "o" };
+	preferences = preferences || {};
 	expandedProperty = expandedProperty || "";
 	vendors = vendors || "";
-	if (vendors[0] == '-') {
-		if (vendors == "-") {
-			let defaultVendors = "-"
-			preferences = preferences || {};
-			let property = expandedProperty.substr(0, expandedProperty.indexOf(':'));
-			property = property || expandedProperty;
-			for (const v in vendorPrefixes) {
-				let vendorProperties = preferences['css.' + vendorPrefixes[v] + 'Properties'];
-				if (vendorProperties && vendorProperties.split(',').find(x => x.trim() === property)) defaultVendors += v;
-			}
-			// If no vendors specified.
-			if (defaultVendors == "-") {
-				vendors = "-wmso-";
-			} else {
-				vendors = defaultVendors + '-';
-			}
-		}
-		vendors = vendors.substr(1);
 
-		let prefixedProperty = "";
-		for (let index = 0; index < vendors.length - 1; index++) {
-			prefixedProperty += '-' + vendorPrefixes[vendors[index]] + '-' + expandedProperty + "\n";
-		}
-		return prefixedProperty + expandedProperty;
+	if (vendors[0] !== '-') {
+		return expandedProperty;
 	}
-	return expandedProperty;
+
+	if (vendors == "-") {
+		let defaultVendors = "-";
+		let property = expandedProperty.substr(0, expandedProperty.indexOf(':'));
+		if (!property) {
+			return expandedProperty;
+		}
+
+		for (const v in vendorPrefixes) {
+			let vendorProperties = preferences['css.' + vendorPrefixes[v] + 'Properties'];
+			if (vendorProperties && vendorProperties.split(',').find(x => x.trim() === property)) defaultVendors += v;
+		}
+
+		// If no vendors specified, add all
+		vendors = defaultVendors == "-" ? "-wmso" : defaultVendors;
+		vendors += '-';
+	}
+	vendors = vendors.substr(1);
+
+	let prefixedProperty = "";
+	for (let index = 0; index < vendors.length - 1; index++) {
+		prefixedProperty += '-' + vendorPrefixes[vendors[index]] + '-' + expandedProperty + "\n";
+	}
+	return prefixedProperty + expandedProperty;
 }
 
 

--- a/src/test/emmetHelperTest.ts
+++ b/src/test/emmetHelperTest.ts
@@ -747,21 +747,17 @@ describe('Test completions', () => {
 
 				['brs', 0, 3, 'border-radius: ;', 'border-radius: |;', 'brs'], 
 				['brs5', 0, 4, 'border-radius: 5px;', 'border-radius: 5px;', 'brs5'], 
-				['-brs', 0, 4, 'border-radius: ;\n-webkit-border-radius: ;\n-moz-border-radius: ;\n-ms-border-radius: ;\n-o-border-radius: ;', 
-					'border-radius: |;\n-webkit-border-radius: |;\n-moz-border-radius: |;\n-ms-border-radius: |;\n-o-border-radius: |;', '-brs'], 
-				['-brs10', 0, 6, 'border-radius: 10px;\n-webkit-border-radius: 10px;\n-moz-border-radius: 10px;\n-ms-border-radius: 10px;\n-o-border-radius: 10px;',
-					'border-radius: 10px;\n-webkit-border-radius: 10px;\n-moz-border-radius: 10px;\n-ms-border-radius: 10px;\n-o-border-radius: 10px;', '-brs10'], 
-				['-bdts', 0, 5, 'border-top-style: ;\n-webkit-border-top-style: ;\n-moz-border-top-style: ;\n-ms-border-top-style: ;\n-o-border-top-style: ;',
-					'border-top-style: |;\n-webkit-border-top-style: |;\n-moz-border-top-style: |;\n-ms-border-top-style: |;\n-o-border-top-style: |;', '-bdts'], 
-				['-p', 0, 2, 'padding: ;\n-webkit-padding: ;\n-moz-padding: ;\n-ms-padding: ;\n-o-padding: ;',
-					'padding: |;\n-webkit-padding: |;\n-moz-padding: |;\n-ms-padding: |;\n-o-padding: |;', '-p'], 
-				['-p10', 0, 4, 'padding: 10px;\n-webkit-padding: 10px;\n-moz-padding: 10px;\n-ms-padding: 10px;\n-o-padding: 10px;',
-					'padding: 10px;\n-webkit-padding: 10px;\n-moz-padding: 10px;\n-ms-padding: 10px;\n-o-padding: 10px;', '-p10'], 
-				['-p10-20', 0, 7, 'padding: 10px 20px;\n-webkit-padding: 10px 20px;\n-moz-padding: 10px 20px;\n-ms-padding: 10px 20px;\n-o-padding: 10px 20px;',
-					'padding: 10px 20px;\n-webkit-padding: 10px 20px;\n-moz-padding: 10px 20px;\n-ms-padding: 10px 20px;\n-o-padding: 10px 20px;', '-p10-20'], 
+				
+				['-brs', 0, 4, 'border-radius: ;', '-webkit-border-radius: |;\n-moz-border-radius: |;\n-ms-border-radius: |;\n-o-border-radius: |;\nborder-radius: |;', '-brs'], 
+				['-mo-brs', 0, 7, 'border-radius: ;', '-moz-border-radius: |;\n-o-border-radius: |;\nborder-radius: |;', '-mo-brs'], 
+				['-om-brs', 0, 7, 'border-radius: ;', '-o-border-radius: |;\n-moz-border-radius: |;\nborder-radius: |;', '-om-brs'], 
+				['-brs10', 0, 6, 'border-radius: 10px;', '-webkit-border-radius: 10px;\n-moz-border-radius: 10px;\n-ms-border-radius: 10px;\n-o-border-radius: 10px;\nborder-radius: 10px;', '-brs10'],
+				['-bdts', 0, 5, 'border-top-style: ;', '-webkit-border-top-style: |;\n-moz-border-top-style: |;\n-ms-border-top-style: |;\n-o-border-top-style: |;\nborder-top-style: |;', '-bdts'], 
+				['-p', 0, 2, 'padding: ;', '-webkit-padding: |;\n-moz-padding: |;\n-ms-padding: |;\n-o-padding: |;\npadding: |;', '-p'],
+				['-p10-20p', 0, 8, 'padding: 10px 20%;', '-webkit-padding: 10px 20%;\n-moz-padding: 10px 20%;\n-ms-padding: 10px 20%;\n-o-padding: 10px 20%;\npadding: 10px 20%;', '-p10-20p'],
 			];
 
-			testCases.forEach(([content, positionLine, positionChar, expectedAbbr, expectedExpansion, expectedFilterText]) => {
+			testCases.forEach(([content, positionLine, positionChar, expectedLabel, expectedExpansion, expectedFilterText]) => {
 				const document = TextDocument.create('test://test/test.css', 'css', 0, content);
 				const position = Position.create(positionLine, positionChar);
 				const completionList = doComplete(document, position, 'css', {
@@ -772,7 +768,7 @@ describe('Test completions', () => {
 					variables: {}
 				});
 
-				assert.equal(completionList.items[0].label, expectedAbbr);
+				assert.equal(completionList.items[0].label, expectedLabel);
 				assert.equal(completionList.items[0].documentation, expectedExpansion);
 				assert.equal(completionList.items[0].filterText, expectedFilterText);
 			});
@@ -786,16 +782,25 @@ describe('Test completions', () => {
 			assert.equal(expandAbbreviation('brs', getExpandOptions('css', {})), 'border-radius: ${0};');
 			assert.equal(expandAbbreviation('brs5', getExpandOptions('css', {})), 'border-radius: 5px;');
 			assert.equal(expandAbbreviation('brs10px', getExpandOptions('css', {})), 'border-radius: 10px;');
-			assert.equal(expandAbbreviation('-brs', getExpandOptions('css', {})), 'border-radius: ${0};\n-webkit-border-radius: ${0};\n-moz-border-radius: ${0};\n-ms-border-radius: ${0};\n-o-border-radius: ${0};');
-			assert.equal(expandAbbreviation('-brs10', getExpandOptions('css', {})), 'border-radius: 10px;\n-webkit-border-radius: 10px;\n-moz-border-radius: 10px;\n-ms-border-radius: 10px;\n-o-border-radius: 10px;');
-			assert.equal(expandAbbreviation('-bdts', getExpandOptions('css', {})), 'border-top-style: ${0};\n-webkit-border-top-style: ${0};\n-moz-border-top-style: ${0};\n-ms-border-top-style: ${0};\n-o-border-top-style: ${0};');
-			assert.equal(expandAbbreviation('-bdts2px', getExpandOptions('css', {})), 'border-top-style: 2px;\n-webkit-border-top-style: 2px;\n-moz-border-top-style: 2px;\n-ms-border-top-style: 2px;\n-o-border-top-style: 2px;');
-			assert.equal(expandAbbreviation('-p10-20', getExpandOptions('css', {})), 'padding: 10px 20px;\n-webkit-padding: 10px 20px;\n-moz-padding: 10px 20px;\n-ms-padding: 10px 20px;\n-o-padding: 10px 20px;');
-			assert.equal(expandAbbreviation('-p10p20', getExpandOptions('css', {})), 'padding: 10% 20px;\n-webkit-padding: 10% 20px;\n-moz-padding: 10% 20px;\n-ms-padding: 10% 20px;\n-o-padding: 10% 20px;');
+			assert.equal(expandAbbreviation('-brs', getExpandOptions('css', {})), '-webkit-border-radius: ${0};\n-moz-border-radius: ${0};\n-ms-border-radius: ${0};\n-o-border-radius: ${0};\nborder-radius: ${0};');
+			assert.equal(expandAbbreviation('-brs10', getExpandOptions('css', {})), '-webkit-border-radius: 10px;\n-moz-border-radius: 10px;\n-ms-border-radius: 10px;\n-o-border-radius: 10px;\nborder-radius: 10px;');
+			assert.equal(expandAbbreviation('-bdts', getExpandOptions('css', {})), '-webkit-border-top-style: ${0};\n-moz-border-top-style: ${0};\n-ms-border-top-style: ${0};\n-o-border-top-style: ${0};\nborder-top-style: ${0};');
+			assert.equal(expandAbbreviation('-bdts2px', getExpandOptions('css', {})), '-webkit-border-top-style: 2px;\n-moz-border-top-style: 2px;\n-ms-border-top-style: 2px;\n-o-border-top-style: 2px;\nborder-top-style: 2px;');
+			assert.equal(expandAbbreviation('-p10-20', getExpandOptions('css', {})), '-webkit-padding: 10px 20px;\n-moz-padding: 10px 20px;\n-ms-padding: 10px 20px;\n-o-padding: 10px 20px;\npadding: 10px 20px;');
+			assert.equal(expandAbbreviation('-p10p20', getExpandOptions('css', {})), '-webkit-padding: 10% 20px;\n-moz-padding: 10% 20px;\n-ms-padding: 10% 20px;\n-o-padding: 10% 20px;\npadding: 10% 20px;');
+			assert.equal(expandAbbreviation('-mo-brs', getExpandOptions('css', {})), '-moz-border-radius: ${0};\n-o-border-radius: ${0};\nborder-radius: ${0};');
 			
-			
-			//assert.equal(expandAbbreviation('-bgp', getExpandOptions('css', {})), 'background-position:${1:0} ${2:0};\n-webkit-background-position:${1:0} ${2:0};\n-moz-background-position:${1:0} ${2:0};\n-ms-background-position:${1:0} ${2:0};\n-o-background-position:${1:0} ${2:0};');
-			//assert.equal(expandAbbreviation('bdr', getExpandOptions('css', {})), 'border-right: ${2:1px} ${3:solid} ${4:#000};');
+			return Promise.resolve();
+		});
+	});
+
+
+	it('should expand with default vendor prefixes in properties', () => {
+		return updateExtensionsPath(null).then(() => {
+			assert.equal(expandAbbreviation('-p', getExpandOptions('css', { preferences: { 'css.webkitProperties': 'foo, bar, padding' } })), '-webkit-padding: ${0};\npadding: ${0};');
+			assert.equal(expandAbbreviation('-p', getExpandOptions('css', { preferences: { 'css.oProperties': 'padding', 'css.webkitProperties': 'padding' } })), '-webkit-padding: ${0};\n-o-padding: ${0};\npadding: ${0};');
+			assert.equal(expandAbbreviation('-brs', getExpandOptions('css', { preferences: { 'css.oProperties': 'padding', 'css.webkitProperties': 'padding' } })), '-webkit-border-radius: ${0};\n-moz-border-radius: ${0};\n-ms-border-radius: ${0};\n-o-border-radius: ${0};\nborder-radius: ${0};');
+			assert.equal(expandAbbreviation('-o-p', getExpandOptions('css', { preferences: { 'css.oProperties': 'padding', 'css.webkitProperties': 'padding' } })), '-o-padding: ${0};\npadding: ${0};');
 
 			return Promise.resolve();
 		});


### PR DESCRIPTION
Fixed error when applying several vendor prefixes to a CSS property, now the one without prefix goes at the end.

Added user-defined default vendors for specific properties. A user can modify his settings to always expand some property with a subset of the vendor prefixes.

Added ability to define specific vendors while typing.
For example `-ow-brs` gets expanded to 
```
-o-border-radius: ;
-webkit-border-radius: ;
border-radius: ;
```
