### PR TITLE
Make jsx class attribute configurable

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -531,7 +531,9 @@ export function getExpandOptions(syntax: string, emmetConfig?: object, filter?: 
 		}
 	}
 	if (syntax === 'jsx') {
-		addons['jsx'] = true;
+		addons['jsx'] = {
+			attributeName: emmetConfig['preferences']['jsx.classAttributeName']
+		};
 	}
 
 	// Fetch Formatters

--- a/src/expand/expand-full.js
+++ b/src/expand/expand-full.js
@@ -2259,9 +2259,9 @@ function find(arr, filter) {
  * JSX transformer: replaces `class` and `for` attributes with `className` and
  * `htmlFor` attributes respectively
  */
-var jsx = function(tree) {
+var jsx = function(tree, options) {
 	tree.walk(node => {
-		replace(node, 'class', 'className');
+		replace(node, 'class', options && options.attributeName ? options.attributeName : 'className');
 		replace(node, 'for', 'htmlFor');
 	});
 	return tree;


### PR DESCRIPTION
It is for [React CSS Modules](https://github.com/gajus/react-css-modules) so we can use `vscode-emmet-helper` to convert `.style` into `<div styleName="style"></div>` just by adding `"emmet.preferences": { "jsx.classAttributeName": "styleName" }`.
