### PR TITLE
Extract css abbreviations inside style tags.

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -87,7 +87,7 @@ export function doComplete(document: TextDocument, position: Position, syntax: s
 		markupSnippetKeys = snippetKeyCache.get(syntax);
 	}
 
-	let extractedValue = extractAbbreviation(document, position, {syntax: 'css'});
+	let extractedValue = extractAbbreviation(document, position, { syntax: 'css' });
 	if (!extractedValue) {
 		return;
 	}
@@ -383,14 +383,14 @@ function getFilters(text: string, pos: number): { pos: number, filter: string } 
 /**
  * Extracts abbreviation from the given position in the given document
  */
-export function extractAbbreviation(document: TextDocument, position: Position, extractOptions: boolean | {lookAhead?: boolean, syntax?: string}): { abbreviation: string, abbreviationRange: Range, filter: string } {
+export function extractAbbreviation(document: TextDocument, position: Position, extractOptions: boolean | { lookAhead?: boolean, syntax?: string }): { abbreviation: string, abbreviationRange: Range, filter: string } {
 	const currentLine = getCurrentLine(document, position);
 	const currentLineTillPosition = currentLine.substr(0, position.character);
 	const { pos, filter } = getFilters(currentLineTillPosition, position.character);
 	const lengthOccupiedByFilter = filter ? filter.length + 1 : 0;
 
 	try {
-		let options: boolean | {lookAhead: boolean, syntax: string};
+		let options: boolean | { lookAhead: boolean, syntax: string };
 		if (typeof extractOptions === 'boolean') {
 			options = extractOptions;
 		} else {
@@ -403,7 +403,7 @@ export function extractAbbreviation(document: TextDocument, position: Position, 
 				syntax = 'markup';
 				lookAhead = typeof extractOptions.lookAhead === 'boolean' ? extractOptions.lookAhead : true;
 			}
-			options = {syntax, lookAhead};
+			options = { syntax, lookAhead };
 		}
 		const result = extract(currentLine, pos, options);
 		const rangeToReplace = Range.create(position.line, result.location, position.line, result.location + result.abbreviation.length + lengthOccupiedByFilter);
@@ -955,14 +955,14 @@ export function getEmmetCompletionParticipants(document: TextDocument, position:
 		},
 		onCssPropertyValue: (context) => {
 			if (context && context.propertyValue) {
-				const extractedResults = extractAbbreviation(document, position, {syntax: 'css'});
+				const extractedResults = extractAbbreviation(document, position, { syntax: 'css' });
 				if (!extractedResults) {
 					return;
 				}
 				const validAbbreviationWithColon = extractedResults.abbreviation === `${context.propertyName}:${context.propertyValue}` && onlyLetters.test(context.propertyValue);
 				if (validAbbreviationWithColon // Allows abbreviations like pos:f
-                    || hexColorRegex.test(extractedResults.abbreviation)
-                    || extractedResults.abbreviation === '!') {
+					|| hexColorRegex.test(extractedResults.abbreviation)
+					|| extractedResults.abbreviation === '!') {
 					const currentresult = doComplete(document, position, syntax, emmetSettings);
 					if (result && currentresult) {
 						result.items = currentresult.items;

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -87,7 +87,7 @@ export function doComplete(document: TextDocument, position: Position, syntax: s
 		markupSnippetKeys = snippetKeyCache.get(syntax);
 	}
 
-	let extractedValue = extractAbbreviation(document, position, { syntax });
+	let extractedValue = extractAbbreviation(document, position, { syntax, lookAhead: !isStyleSheet(syntax) });
 	if (!extractedValue) {
 		return;
 	}
@@ -382,22 +382,12 @@ function getFilters(text: string, pos: number): { pos: number, filter: string } 
 }
 
 function getExtractOptions(options?: boolean | { lookAhead?: boolean, syntax?: string }): boolean | { lookAhead: boolean, syntax: string } {
-	let extractOptions: boolean | { lookAhead: boolean, syntax: string };
 	if (typeof options === 'boolean') {
 		return options;
 	} else if (!options) {
 		return { lookAhead: true, syntax: 'markup' };
 	} else {
-		let syntax: string;
-		let lookAhead: boolean;
-		if (isStyleSheet(options.syntax)) {
-			syntax = 'stylesheet';
-			lookAhead = options.lookAhead || false;
-		} else {
-			syntax = 'markup';
-			lookAhead = options.lookAhead;
-		}
-		return { syntax, lookAhead };
+		return { syntax: isStyleSheet(options.syntax) ? 'stylesheet' : 'markup', lookAhead: options.lookAhead };
 	}
 }
 /**
@@ -962,7 +952,7 @@ export function getEmmetCompletionParticipants(document: TextDocument, position:
 		},
 		onCssPropertyValue: (context) => {
 			if (context && context.propertyValue) {
-				const extractedResults = extractAbbreviation(document, position, { syntax: 'css' });
+				const extractedResults = extractAbbreviation(document, position, { syntax: 'css', lookAhead: false });
 				if (!extractedResults) {
 					return;
 				}

--- a/src/test/emmetHelperTest.ts
+++ b/src/test/emmetHelperTest.ts
@@ -60,7 +60,7 @@ describe('Validate Abbreviations', () => {
 });
 
 describe('Extract Abbreviations', () => {
-	it('should extract abbreviations from document', () => {
+	it('should extract abbreviations from document html', () => {
 		const testCases: [string, number, number, string, number, number, number, number, string][] = [
 			['<div>ul>li*3</div>', 0, 7, 'ul', 0, 5, 0, 7, undefined],
 			['<div>ul>li*3</div>', 0, 10, 'ul>li', 0, 5, 0, 10, undefined],
@@ -79,6 +79,26 @@ describe('Extract Abbreviations', () => {
 			const document = TextDocument.create('test://test/test.html', 'html', 0, content);
 			const position = Position.create(positionLine, positionChar);
 			const { abbreviationRange, abbreviation, filter } = extractAbbreviation(document, position);
+
+			assert.equal(expectedAbbr, abbreviation);
+			assert.equal(expectedRangeStartLine, abbreviationRange.start.line);
+			assert.equal(expectedRangeStartChar, abbreviationRange.start.character);
+			assert.equal(expectedRangeEndLine, abbreviationRange.end.line);
+			assert.equal(expectedRangeEndChar, abbreviationRange.end.character);
+			assert.equal(filter, expectedFilter);
+		});
+	});
+	it('should extract abbreviations from document css', () => {
+		const testCases: [string, number, number, string, number, number, number, number, string][] = [
+			['<div style="dn"></div>', 0, 14, 'dn', 0, 12, 0, 14, undefined],
+			['<div style="trf:rx"></div>', 0, 18, 'trf:rx', 0, 12, 0, 18, undefined],
+			['<div style="-mwo-trf:rx"></div>', 0, 23, '-mwo-trf:rx', 0, 12, 0, 23, undefined],
+		]
+
+		testCases.forEach(([content, positionLine, positionChar, expectedAbbr, expectedRangeStartLine, expectedRangeStartChar, expectedRangeEndLine, expectedRangeEndChar, expectedFilter]) => {
+			const document = TextDocument.create('test://test/test.html', 'html', 0, content);
+			const position = Position.create(positionLine, positionChar);
+			const { abbreviationRange, abbreviation, filter } = extractAbbreviation(document, position, undefined, 'css');
 
 			assert.equal(expectedAbbr, abbreviation);
 			assert.equal(expectedRangeStartLine, abbreviationRange.start.line);

--- a/src/test/emmetHelperTest.ts
+++ b/src/test/emmetHelperTest.ts
@@ -21,8 +21,8 @@ const expectedCommentFilterOutput =
 <!-- /.nav -->`;
 const expectedCommentFilterOutputDocs = expectedCommentFilterOutput.replace(/\$\{\d+\}/g, '|');
 const bemCommentFilterExample = bemFilterExample;
-const expectedBemCommentFilterOutput = 
-`<ul class="search-form search-form_wide">
+const expectedBemCommentFilterOutput =
+	`<ul class="search-form search-form_wide">
 	<li class="search-form__querystring">\${1}</li>
 	<!-- /.search-form__querystring -->
 	<li class="search-form__btn search-form__btn_large">\${0}</li>
@@ -70,8 +70,8 @@ describe('Extract Abbreviations', () => {
 			['ul>li|c|bem', 0, 11, 'ul>li', 0, 0, 0, 11, 'c,bem'],
 			['ul>li|bem|c', 0, 11, 'ul>li', 0, 0, 0, 11, 'bem,c'],
 			['ul>li|t|bem|c', 0, 13, 'ul>li', 0, 0, 0, 13, 't,bem,c'],
-			['div[a="b" c="d"]>md-button', 0, 26, 'div[a="b" c="d"]>md-button', 0, 0, 0, 26, undefined],			
-			['div[a=b c="d"]>md-button', 0, 24, 'div[a=b c="d"]>md-button', 0, 0, 0, 24, undefined],			
+			['div[a="b" c="d"]>md-button', 0, 26, 'div[a="b" c="d"]>md-button', 0, 0, 0, 26, undefined],
+			['div[a=b c="d"]>md-button', 0, 24, 'div[a=b c="d"]>md-button', 0, 0, 0, 24, undefined],
 			['div[a=b c=d]>md-button', 0, 22, 'div[a=b c=d]>md-button', 0, 0, 0, 22, undefined]
 		]
 
@@ -98,7 +98,7 @@ describe('Extract Abbreviations', () => {
 		testCases.forEach(([content, positionLine, positionChar, expectedAbbr, expectedRangeStartLine, expectedRangeStartChar, expectedRangeEndLine, expectedRangeEndChar, expectedFilter]) => {
 			const document = TextDocument.create('test://test/test.html', 'html', 0, content);
 			const position = Position.create(positionLine, positionChar);
-			const { abbreviationRange, abbreviation, filter } = extractAbbreviation(document, position, undefined, 'css');
+			const { abbreviationRange, abbreviation, filter } = extractAbbreviation(document, position, { syntax: 'css' });
 
 			assert.equal(expectedAbbr, abbreviation);
 			assert.equal(expectedRangeStartLine, abbreviationRange.start.line);
@@ -457,9 +457,9 @@ describe('Test completions', () => {
 				[bemFilterExampleWithInlineFilter, 0, bemFilterExampleWithInlineFilter.length, bemFilterExampleWithInlineFilter, expectedBemFilterOutputDocs, expectedBemFilterOutput],
 				[commentFilterExampleWithInlineFilter, 0, commentFilterExampleWithInlineFilter.length, commentFilterExampleWithInlineFilter, expectedCommentFilterOutputDocs, expectedCommentFilterOutput],
 				[bemCommentFilterExampleWithInlineFilter, 0, bemCommentFilterExampleWithInlineFilter.length, bemCommentFilterExampleWithInlineFilter, expectedBemCommentFilterOutputDocs, expectedBemCommentFilterOutput],
-				[commentBemFilterExampleWithInlineFilter, 0, commentBemFilterExampleWithInlineFilter.length, commentBemFilterExampleWithInlineFilter, expectedBemCommentFilterOutputDocs, expectedBemCommentFilterOutput],				
+				[commentBemFilterExampleWithInlineFilter, 0, commentBemFilterExampleWithInlineFilter.length, commentBemFilterExampleWithInlineFilter, expectedBemCommentFilterOutputDocs, expectedBemCommentFilterOutput],
 				['li*2+link:css', 0, 13, 'li*2+link:css', '<li>|</li>\n<li>|</li>\n<link rel="stylesheet" href="style.css">', '<li>\${1}</li>\n<li>\${2}</li>\n<link rel="stylesheet" href="\${4:style}.css">'], // No last tab stop gets added as max tab stop is of a placeholder
-				['li*10', 0, 5, 'li*10', '<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>', 
+				['li*10', 0, 5, 'li*10', '<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>\n<li>|</li>',
 					'<li>\${1}</li>\n<li>\${2}</li>\n<li>\${3}</li>\n<li>\${4}</li>\n<li>\${5}</li>\n<li>\${6}</li>\n<li>\${7}</li>\n<li>\${8}</li>\n<li>\${9}</li>\n<li>\${0}</li>'], // tabstop 10 es greater than 9, should be replaced by 0
 			];
 
@@ -828,14 +828,14 @@ describe('Test completions', () => {
 		return updateExtensionsPath(extensionsPath).then(() => {
 			const testCases: [string, number, number, string, string, string][] = [
 
-				['brs', 0, 3, 'border-radius: ;', 'border-radius: |;', 'brs'], 
-				['brs5', 0, 4, 'border-radius: 5px;', 'border-radius: 5px;', 'brs5'], 
-				
-				['-brs', 0, 4, 'border-radius: ;', '-webkit-border-radius: |;\n-moz-border-radius: |;\nborder-radius: |;', '-brs'], 
-				['-mo-brs', 0, 7, 'border-radius: ;', '-moz-border-radius: |;\n-o-border-radius: |;\nborder-radius: |;', '-mo-brs'], 
-				['-om-brs', 0, 7, 'border-radius: ;', '-o-border-radius: |;\n-moz-border-radius: |;\nborder-radius: |;', '-om-brs'], 
+				['brs', 0, 3, 'border-radius: ;', 'border-radius: |;', 'brs'],
+				['brs5', 0, 4, 'border-radius: 5px;', 'border-radius: 5px;', 'brs5'],
+
+				['-brs', 0, 4, 'border-radius: ;', '-webkit-border-radius: |;\n-moz-border-radius: |;\nborder-radius: |;', '-brs'],
+				['-mo-brs', 0, 7, 'border-radius: ;', '-moz-border-radius: |;\n-o-border-radius: |;\nborder-radius: |;', '-mo-brs'],
+				['-om-brs', 0, 7, 'border-radius: ;', '-o-border-radius: |;\n-moz-border-radius: |;\nborder-radius: |;', '-om-brs'],
 				['-brs10', 0, 6, 'border-radius: 10px;', '-webkit-border-radius: 10px;\n-moz-border-radius: 10px;\nborder-radius: 10px;', '-brs10'],
-				['-bdts', 0, 5, 'border-top-style: ;', '-webkit-border-top-style: |;\n-moz-border-top-style: |;\n-ms-border-top-style: |;\n-o-border-top-style: |;\nborder-top-style: |;', '-bdts'], 
+				['-bdts', 0, 5, 'border-top-style: ;', '-webkit-border-top-style: |;\n-moz-border-top-style: |;\n-ms-border-top-style: |;\n-o-border-top-style: |;\nborder-top-style: |;', '-bdts'],
 				['-p', 0, 2, 'padding: ;', '-webkit-padding: |;\n-moz-padding: |;\n-ms-padding: |;\n-o-padding: |;\npadding: |;', '-p'],
 				['-p10-20p', 0, 8, 'padding: 10px 20%;', '-webkit-padding: 10px 20%;\n-moz-padding: 10px 20%;\n-ms-padding: 10px 20%;\n-o-padding: 10px 20%;\npadding: 10px 20%;', '-p10-20p'],
 			];
@@ -907,7 +907,7 @@ describe('Test completions', () => {
 			assert.equal(expandAbbreviation('-p10-20', getExpandOptions('css', {})), '-webkit-padding: 10px 20px;\n-moz-padding: 10px 20px;\n-ms-padding: 10px 20px;\n-o-padding: 10px 20px;\npadding: 10px 20px;');
 			assert.equal(expandAbbreviation('-p10p20', getExpandOptions('css', {})), '-webkit-padding: 10% 20px;\n-moz-padding: 10% 20px;\n-ms-padding: 10% 20px;\n-o-padding: 10% 20px;\npadding: 10% 20px;');
 			assert.equal(expandAbbreviation('-mo-brs', getExpandOptions('css', {})), '-moz-border-radius: ${0};\n-o-border-radius: ${0};\nborder-radius: ${0};');
-			
+
 			return Promise.resolve();
 		});
 	});
@@ -925,7 +925,7 @@ describe('Test completions', () => {
 	});
 
 	it('should not provide completions for exlcudedLanguages', () => {
-		return updateExtensionsPath(null).then(() => { 
+		return updateExtensionsPath(null).then(() => {
 			const document = TextDocument.create('test://test/test.html', 'html', 0, 'ul>li');
 			const position = Position.create(0, 5);
 			const completionList = doComplete(document, position, 'html', {
@@ -941,7 +941,7 @@ describe('Test completions', () => {
 	});
 
 	it('should provide completions with kind snippet when showSuggestionsAsSnippets is enabled', () => {
-		return updateExtensionsPath(null).then(() => { 
+		return updateExtensionsPath(null).then(() => {
 			const document = TextDocument.create('test://test/test.html', 'html', 0, 'ul>li');
 			const position = Position.create(0, 5);
 			const completionList = doComplete(document, position, 'html', {

--- a/src/test/emmetHelperTest.ts
+++ b/src/test/emmetHelperTest.ts
@@ -98,7 +98,7 @@ describe('Extract Abbreviations', () => {
 		testCases.forEach(([content, positionLine, positionChar, expectedAbbr, expectedRangeStartLine, expectedRangeStartChar, expectedRangeEndLine, expectedRangeEndChar, expectedFilter]) => {
 			const document = TextDocument.create('test://test/test.html', 'html', 0, content);
 			const position = Position.create(positionLine, positionChar);
-			const { abbreviationRange, abbreviation, filter } = extractAbbreviation(document, position, { syntax: 'css' });
+			const { abbreviationRange, abbreviation, filter } = extractAbbreviation(document, position, { syntax: 'css', lookAhead: false });
 
 			assert.equal(expectedAbbr, abbreviation);
 			assert.equal(expectedRangeStartLine, abbreviationRange.start.line);


### PR DESCRIPTION
Fix for https://github.com/Microsoft/vscode/issues/29066