### PR TITLE
Put a newline between nodes when only 2 nodes are in a parent

### DIFF
--- a/src/expand/expand-full.js
+++ b/src/expand/expand-full.js
@@ -53,7 +53,7 @@ var defaultOptions$1 = {
 	 * Set to 1 to output all inline elements with formatting (same as block-level).
 	 * @type {Number}
 	 */
-	inlineBreak: 3,
+	inlineBreak: 2,
 
 	/**
 	 * Produce compact notation of boolean attribues: attributes where name equals value.

--- a/src/test/emmetHelperTest.ts
+++ b/src/test/emmetHelperTest.ts
@@ -863,8 +863,6 @@ describe('Test completions', () => {
 
 	it('should provide completions for loremn with n words', () => {
 		return updateExtensionsPath(null).then(() => {
-
-
 			const document = TextDocument.create('test://test/test.html', 'html', 0, 'lorem10.item');
 			const position = Position.create(0, 12);
 			const completionList = doComplete(document, position, 'html', {
@@ -889,10 +887,56 @@ describe('Test completions', () => {
 		});
 	});
 
-	it('should provide completions for lorem*n with n lines', () => {
+	it('should provide completions for lorem*1 with 1 lines', () => {
 		return updateExtensionsPath(null).then(() => {
+			const document = TextDocument.create('test://test/test.html', 'html', 0, 'lorem*1');
+			const position = Position.create(0, 12);
+			const completionList = doComplete(document, position, 'html', {
+				preferences: {},
+				showExpandedAbbreviation: 'always',
+				showAbbreviationSuggestions: false,
+				syntaxProfiles: {},
+				variables: {}
+			});
+			const expandedText = completionList.items[0].documentation;
+			if (typeof expandedText !== 'string') {
+				return;
+			}
 
+			assert.equal(completionList.items[0].label, 'lorem*1');
+			assert.equal(expandedText.split('\n').length, 1);
+			assert.equal(expandedText.startsWith('Lorem'), true);
 
+			return Promise.resolve();
+		});
+	});
+
+	it('should provide completions for lorem*2 with 2 lines', () => {
+		return updateExtensionsPath(null).then(() => {
+			const document = TextDocument.create('test://test/test.html', 'html', 0, 'lorem*2');
+			const position = Position.create(0, 12);
+			const completionList = doComplete(document, position, 'html', {
+				preferences: {},
+				showExpandedAbbreviation: 'always',
+				showAbbreviationSuggestions: false,
+				syntaxProfiles: {},
+				variables: {}
+			});
+			const expandedText = completionList.items[0].documentation;
+			if (typeof expandedText !== 'string') {
+				return;
+			}
+
+			assert.equal(completionList.items[0].label, 'lorem*2');
+			assert.equal(expandedText.split('\n').length, 2);
+			assert.equal(expandedText.startsWith('Lorem'), true);
+
+			return Promise.resolve();
+		});
+	});
+
+	it('should provide completions for lorem*3 with 3 lines', () => {
+		return updateExtensionsPath(null).then(() => {
 			const document = TextDocument.create('test://test/test.html', 'html', 0, 'lorem*3');
 			const position = Position.create(0, 12);
 			const completionList = doComplete(document, position, 'html', {
@@ -906,9 +950,33 @@ describe('Test completions', () => {
 			if (typeof expandedText !== 'string') {
 				return;
 			}
-		
+
 			assert.equal(completionList.items[0].label, 'lorem*3');
 			assert.equal(expandedText.split('\n').length, 3);
+			assert.equal(expandedText.startsWith('Lorem'), true);
+
+			return Promise.resolve();
+		});
+	});
+
+	it('should provide completions for lorem*10 with 10 lines', () => {
+		return updateExtensionsPath(null).then(() => {
+			const document = TextDocument.create('test://test/test.html', 'html', 0, 'lorem*10');
+			const position = Position.create(0, 12);
+			const completionList = doComplete(document, position, 'html', {
+				preferences: {},
+				showExpandedAbbreviation: 'always',
+				showAbbreviationSuggestions: false,
+				syntaxProfiles: {},
+				variables: {}
+			});
+			const expandedText = completionList.items[0].documentation;
+			if (typeof expandedText !== 'string') {
+				return;
+			}
+
+			assert.equal(completionList.items[0].label, 'lorem*10');
+			assert.equal(expandedText.split('\n').length, 10);
 			assert.equal(expandedText.startsWith('Lorem'), true);
 
 			return Promise.resolve();


### PR DESCRIPTION
## Overview
Fix https://github.com/Microsoft/vscode/issues/52345.

## Investigation

[There's a logic determining if a node should have be formatted](https://github.com/Microsoft/vscode-emmet-helper/blob/master/src/expand/expand-full.js#L3135-L3151). It uses inlineBreak, which is the option `inline_break` with default value of 3.

In short, an emmet*2 couldn't generate 2 lines since the number of lines was less than 3.

## Solution
Just set the default value of `inline_break` to 2.

## Note
- I've specialized a test case since it needs more test cases
- It'd be nice to announce the change of default value of `inline_break`