### PR TITLE
Fix issue #31

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -490,8 +490,8 @@ export function isAbbreviationValid(syntax: string, abbreviation: string): boole
 		return parseInt(multipleMatch[1], 10) <= 100
 	}
 	// Its common for users to type (sometextinsidebrackets), this should not be treated as an abbreviation
-	// Grouping in abbreviation is valid only if preceeded/succeeded with one of the symbols for nesting, sibling, repeater or climb up
-	if (!/\(.*\)[>\+\*\^]/.test(abbreviation) && !/[>\+\*\^]\(.*\)/.test(abbreviation) && /\(/.test(abbreviation) && /\)/.test(abbreviation)) {
+	// Grouping in abbreviation is valid only if it's inside a text node or preceeded/succeeded with one of the symbols for nesting, sibling, repeater or climb up
+	if (!/\{[^\}]*\(.*\)[^\{]*\}/.test(abbreviation) && !/\(.*\)[>\+\*\^]/.test(abbreviation) && !/[>\+\*\^]\(.*\)/.test(abbreviation) && /\(/.test(abbreviation) && /\)/.test(abbreviation)) {
 		return false;
 	}
 

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -491,7 +491,7 @@ export function isAbbreviationValid(syntax: string, abbreviation: string): boole
 	}
 	// Its common for users to type (sometextinsidebrackets), this should not be treated as an abbreviation
 	// Grouping in abbreviation is valid only if it's inside a text node or preceeded/succeeded with one of the symbols for nesting, sibling, repeater or climb up
-	if (!/\{[^\}]*\(.*\)[^\{]*\}/.test(abbreviation) && !/\(.*\)[>\+\*\^]/.test(abbreviation) && !/[>\+\*\^]\(.*\)/.test(abbreviation) && /\(/.test(abbreviation) && /\)/.test(abbreviation)) {
+	if ((/\(/.test(abbreviation) || /\)/.test(abbreviation)) && !/\{[^\}\{]*[\(\)]+[^\}\{]*\}(?:[>\+\*\^]|$)/.test(abbreviation) && !/\(.*\)[>\+\*\^]/.test(abbreviation) && !/[>\+\*\^]\(.*\)/.test(abbreviation)) {
 		return false;
 	}
 

--- a/src/test/emmetHelper.test.ts
+++ b/src/test/emmetHelper.test.ts
@@ -33,7 +33,24 @@ const expectedBemCommentFilterOutputDocs = expectedBemCommentFilterOutput.replac
 
 describe('Validate Abbreviations', () => {
 	it('should return true for valid abbreviations', () => {
-		const htmlAbbreviations = ['ul>li', 'ul', 'h1', 'ul>li*3', '(ul>li)+div', '.hello', '!', '#hello', '.item[id=ok]', '.', '.foo', 'div{ foo (bar) baz }', 'div{ foo ((( abc }', 'div{()}', 'div{ a (b) c}', 'div{ a (b) c}+div{ a (( }'];
+		const htmlAbbreviations = [
+			'ul>li',
+			'ul',
+			'h1',
+			'ul>li*3',
+			'(ul>li)+div',
+			'.hello',
+			'!',
+			'#hello',
+			'.item[id=ok]',
+			'.',
+			'.foo',
+			'div{ foo (bar) baz }',
+			'div{ foo ((( abc }',
+			'div{()}',
+			'div{ a (b) c}',
+			'div{ a (b) c}+div{ a (( }'
+		];
 		const cssAbbreviations = ['#123', '#abc'];
 		htmlAbbreviations.forEach(abbr => {
 			assert(isAbbreviationValid('html', abbr), `${abbr} should be treated as valid abbreviation`);

--- a/src/test/emmetHelper.test.ts
+++ b/src/test/emmetHelper.test.ts
@@ -33,7 +33,7 @@ const expectedBemCommentFilterOutputDocs = expectedBemCommentFilterOutput.replac
 
 describe('Validate Abbreviations', () => {
 	it('should return true for valid abbreviations', () => {
-		const htmlAbbreviations = ['ul>li', 'ul', 'h1', 'ul>li*3', '(ul>li)+div', '.hello', '!', '#hello', '.item[id=ok]', '.', '.foo'];
+		const htmlAbbreviations = ['ul>li', 'ul', 'h1', 'ul>li*3', '(ul>li)+div', '.hello', '!', '#hello', '.item[id=ok]', '.', '.foo', 'div{ foo (bar) baz }'];
 		const cssAbbreviations = ['#123', '#abc'];
 		htmlAbbreviations.forEach(abbr => {
 			assert(isAbbreviationValid('html', abbr));
@@ -61,6 +61,7 @@ describe('Validate Abbreviations', () => {
 			'if(!ok)',
 			'while(!ok)',
 			'(!ok)',
+			'div{ foo }(bar){ baz }'
 		];
 		const cssAbbreviations = ['123', '#xyz'];
 		htmlAbbreviations.forEach(abbr => {

--- a/src/test/emmetHelper.test.ts
+++ b/src/test/emmetHelper.test.ts
@@ -33,13 +33,13 @@ const expectedBemCommentFilterOutputDocs = expectedBemCommentFilterOutput.replac
 
 describe('Validate Abbreviations', () => {
 	it('should return true for valid abbreviations', () => {
-		const htmlAbbreviations = ['ul>li', 'ul', 'h1', 'ul>li*3', '(ul>li)+div', '.hello', '!', '#hello', '.item[id=ok]', '.', '.foo', 'div{ foo (bar) baz }'];
+		const htmlAbbreviations = ['ul>li', 'ul', 'h1', 'ul>li*3', '(ul>li)+div', '.hello', '!', '#hello', '.item[id=ok]', '.', '.foo', 'div{ foo (bar) baz }', 'div{ foo ((( abc }', 'div{()}', 'div{ a (b) c}', 'div{ a (b) c}+div{ a (( }'];
 		const cssAbbreviations = ['#123', '#abc'];
 		htmlAbbreviations.forEach(abbr => {
-			assert(isAbbreviationValid('html', abbr));
+			assert(isAbbreviationValid('html', abbr), `${abbr} should be treated as valid abbreviation`);
 		});
 		htmlAbbreviations.forEach(abbr => {
-			assert(isAbbreviationValid('haml', abbr));
+			assert(isAbbreviationValid('haml', abbr), `${abbr} should be treated as valid abbreviation`);
 		});
 		cssAbbreviations.forEach(abbr => {
 			assert(isAbbreviationValid('css', abbr), `${abbr} should be treated as valid abbreviation`);
@@ -61,7 +61,12 @@ describe('Validate Abbreviations', () => {
 			'if(!ok)',
 			'while(!ok)',
 			'(!ok)',
-			'div{ foo }(bar){ baz }'
+			'div{ foo }(bar){ baz }',
+			'div{ foo ((}( abc }',
+			'div{ a}(b) c}',
+			'div{ a (b){c}',
+			'div{ a}(b){c}',
+			'div{ a ((  dsf} d (( sf )) }'
 		];
 		const cssAbbreviations = ['123', '#xyz'];
 		htmlAbbreviations.forEach(abbr => {


### PR DESCRIPTION
Fixes [#31](https://github.com/microsoft/vscode-emmet-helper/issues/31)
Fixes [microsoft/vscode #77776](https://github.com/microsoft/vscode/issues/77776)

~~The RegEx `/\{[^\}]*\(.*\)[^\{]*\}/` [looks good to me](https://regexr.com/4hiq3)...~~
~~Heh nope, doesn't allow `div { a (b c }` and even `div { a ((( }`. One fix could be to use `/\{[^\}\{]*\}/` but that would allow things like `div { a }(b){ c}` also...~~

~~So till I figure out a good way to fix this, consider this PR as a draft.~~
Okay so with the second commit the fix looks good to me. I have also added a bunch of tests. It did involve a little trial-and-error but I guess the tests are covering enough cases.

Also there was a minor mistake where the condition does a `/\(/.test(abbreviation) && /\)/.test(abbreviation)` to check if it has parentheses but it should be `||` instead.

/cc @ramya-rao-a @octref 