### PR TITLE
For Emmet expansion of d: should expand to "display: block" instead of "display: grid"

### DIFF
--- a/src/expand/expand-full.js
+++ b/src/expand/expand-full.js
@@ -5191,7 +5191,7 @@ var css$1 = {
 	"cp": "clip:auto|rect(${1:top} ${2:right} ${3:bottom} ${4:left})",
 	"cps": "caption-side:top|bottom",
 	"cur": "cursor:pointer|auto|default|crosshair|hand|help|move|pointer|text",
-	"d": "display:grid|inline-grid|subgrid|block|none|flex|inline-flex|inline|inline-block|list-item|run-in|compact|table|inline-table|table-caption|table-column|table-column-group|table-header-group|table-footer-group|table-row|table-row-group|table-cell|ruby|ruby-base|ruby-base-group|ruby-text|ruby-text-group",
+	"d": "display:block|grid|inline-grid|subgrid|none|flex|inline-flex|inline|inline-block|list-item|run-in|compact|table|inline-table|table-caption|table-column|table-column-group|table-header-group|table-footer-group|table-row|table-row-group|table-cell|ruby|ruby-base|ruby-base-group|ruby-text|ruby-text-group",
 	"ec": "empty-cells:show|hide",
 	"f": "font:${1:1em} ${2:sans-serif}",
 	"fd": "font-display:auto|block|swap|fallback|optional",


### PR DESCRIPTION
### Overview

This PR fixes the issue of Emmet css autocompletion for `d` incorrectly completes to `display: grid` [Issue Link](https://github.com/microsoft/vscode/issues/92120)

For expanding the display value it was picking the first value which was overridden by the [commit](https://github.com/microsoft/vscode-emmet-helper/commit/902d3a0f4ec46629026ed3a727546c62f0fc1f21)

I have now restored the order of Block and this seems to have fixed the issue.

Attaching screenshot for reference

![image](https://user-images.githubusercontent.com/16225376/88791491-6f9cf880-d1b7-11ea-8711-33982ad1a20a.png)
