### PR TITLE
Fix testing on VS Code on Windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,14 +8,19 @@
             "type": "node",
             "request": "launch",
             "name": "Mocha Tests",
-            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
             "args": [
                 "-u",
                 "tdd",
                 "--timeout",
                 "999999",
                 "--colors",
-                "${workspaceRoot}/lib/cjs/test/**/*.test.js"
+                "${workspaceFolder}/lib/cjs/test/**/*.test.js"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "skipFiles": [
+                "<node_internals>/**/*.js"
             ],
             "sourceMaps": true,
             "outFiles": [

--- a/src/fileService.ts
+++ b/src/fileService.ts
@@ -52,7 +52,7 @@ const Slash = '/'.charCodeAt(0);
 const Dot = '.'.charCodeAt(0);
 
 export function isAbsolutePath(path: string) {
-	return path.charCodeAt(0) === Slash;
+	return path.charCodeAt(0) === Slash || (path.length >= 3 && path.substring(1).startsWith(":\\"));
 }
 
 export function resolvePath(uri: Uri, path: string): Uri {


### PR DESCRIPTION
Changes:

- Changed `launch.json` so that the test can be launched inside of VS Code, rather than having to run yarn test from a separate window. This way, one can debug the tests more easily within VS Code
- Added a check within `isAbsolutePath` to detect absolute Windows paths such as `C:\`. In turn, tests that search for the settings file can now find it on Windows.

Testing:

- `yarn; yarn compile` within Windows Terminal
- Press `F5` within VS Code on Windows and the tests should run. 
  - All tests should pass. 
  - Any breakpoints set within the .ts files should also hit (debugging works)