### PR TITLE
Fix for 114923 - HTML figcaption tag should be suggested when using the full word

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -7,6 +7,6 @@ export const htmlData = {
         "body", "head", "html",
         "address", "blockquote", "dd", "div", "section", "article", "aside", "header", "footer", "nav", "menu", "dl", "dt", "fieldset", "form", "frame", "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "iframe", "noframes", "object", "ol", "p", "ul", "applet", "center", "dir", "hr", "pre",
         "a", "abbr", "acronym", "area", "b", "base", "basefont", "bdo", "big", "br", "button", "caption", "cite", "code", "col", "colgroup", "del", "dfn", "em", "font", "i", "img", "input", "ins", "isindex", "kbd", "label", "legend", "li", "link", "map", "meta", "noscript", "optgroup", "option", "param", "q", "s", "samp", "script", "select", "small", "span", "strike", "strong", "style", "sub", "sup", "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "title", "tr", "tt", "u", "var",
-        "canvas", "main", "figure", "plaintext"
+        "canvas", "main", "figure", "plaintext", "figcaption"
     ]
 }

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -137,7 +137,7 @@ describe('Expand Abbreviations', () => {
 	testExpand('html', 'a.dropdown-item[href=#]{foo}', '<a href="#" class="dropdown-item">foo</a>', { "output.reverseAttributes": false });
 	testExpand('html', 'a.dropdown-item[href=#]{foo}', '<a class="dropdown-item" href="#">foo</a>', { "output.reverseAttributes": true });
 
-  // https://github.com/microsoft/vscode/issues/114923
+  	// https://github.com/microsoft/vscode/issues/114923
 	testExpand('html', 'figcaption', '<figcaption></figcaption>');
 });
 

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -131,6 +131,9 @@ describe('Expand Abbreviations', () => {
 	testExpand('html', 'span{\\$5}', '<span>\\$5</span>');
 	testExpand('html', 'span{\\$hello}', '<span>\\$hello</span>');
 	testExpand('html', 'ul>li.item$*2{test\\$}', '<ul>\n\t<li class="item1">test\\$</li>\n\t<li class="item2">test\\$</li>\n</ul>');
+
+	// https://github.com/microsoft/vscode/issues/114923
+	testExpand('html', 'figcaption', '<figcaption></figcaption>');
 });
 
 describe('Wrap Abbreviations (basic)', () => {

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -138,7 +138,7 @@ describe('Expand Abbreviations', () => {
 	testExpand('html', 'a.dropdown-item[href=#]{foo}', '<a class="dropdown-item" href="#">foo</a>', { "output.reverseAttributes": true });
 
   	// https://github.com/microsoft/vscode/issues/114923
-	testExpand('html', 'figcaption', '<figcaption></figcaption>');
+	testExpandWithCompletion('html', 'figcaption', '<figcaption></figcaption>');
 });
 
 describe('Wrap Abbreviations (basic)', () => {

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -138,7 +138,7 @@ describe('Expand Abbreviations', () => {
 	testExpand('html', 'a.dropdown-item[href=#]{foo}', '<a class="dropdown-item" href="#">foo</a>', { "output.reverseAttributes": true });
 
   	// https://github.com/microsoft/vscode/issues/114923
-	testExpand('html', 'figcaption', '<figcaption></figcaption>');
+	testExpandWithCompletion('html', 'figcaption', '<figcaption>${0}</figcaption>');
 });
 
 describe('Wrap Abbreviations (basic)', () => {


### PR DESCRIPTION
Fix for [Issue](https://github.com/microsoft/vscode/issues/114923) - HTML figcaption tag should be suggested when using the full word instead of only "figc" 
![Screenshot (2)](https://user-images.githubusercontent.com/22296767/107084982-d150b600-681d-11eb-8922-f2f6512fc75d.png)