### PR TITLE
Fixes 115946(vscode): Add '{' to htmlAbbreviationStartRegex

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -31,7 +31,7 @@ export { FileService, FileType, FileStat }
 const snippetKeyCache = new Map<string, string[]>();
 let markupSnippetKeys: string[];
 const stylesheetCustomSnippetsKeyCache = new Map<string, string[]>();
-const htmlAbbreviationStartRegex = /^[a-z,A-Z,!,(,[,#,\.]/;
+const htmlAbbreviationStartRegex = /^[a-z,A-Z,!,(,[,#,\.\{]/;
 const cssAbbreviationRegex = /^-?[a-z,A-Z,!,@,#]/;
 const htmlAbbreviationRegex = /[a-z,A-Z\.]/;
 const commonlyUsedTags = [...htmlData.tags, 'lorem'];


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/115946

https://user-images.githubusercontent.com/17052177/107138159-1c6de480-6956-11eb-9c83-4b79f9bf43ca.mp4

When expanding repeat abbreviation, newline characters are inserted. This comes from https://github.com/emmetio/emmet.

![Screenshot from 2021-02-07 15-11-58](https://user-images.githubusercontent.com/17052177/107138271-dcf3c800-6956-11eb-8c11-1ace1b8b63e9.png)
