### PR TITLE
provide completions for pascal-case tags when typing jsx

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -544,13 +544,20 @@ function isExpandedTextNoise(syntax: string, abbreviation: string, expandedText:
 		return false;
 	}
 
-	const dotMatches = abbreviation.match(/^([a-z,A-Z,\d]*)\.$/)
+	const dotMatches = abbreviation.match(/^([a-z,A-Z,\d]*)\.$/);
 	if (dotMatches) {
 		// Valid html tags such as `div.`
 		if (dotMatches[1] && htmlData.tags.includes(dotMatches[1])) {
-			return false
+			return false;
 		}
 		return true;
+	}
+
+	// Fix for https://github.com/microsoft/vscode/issues/89746
+	// PascalCase tags are common in jsx code, which should not be treated as noise.
+	// Eg: MyAwesomComponent -> <MyAwesomComponent></MyAwesomComponent>
+	if (syntax === 'jsx' && /^([A-Z][A-Za-z0-9]*)+$/.test(abbreviation)) {
+		return false;
 	}
 
 	// Unresolved html abbreviations get expanded as if it were a tag

--- a/src/test/emmetHelper.test.ts
+++ b/src/test/emmetHelper.test.ts
@@ -954,6 +954,28 @@ describe('Test completions', () => {
 		});
 	});
 
+	it('should provide completions for pascal-case tags when typing (jsx)', async () => {
+		await updateExtensionsPath(null);
+		const testCases: [string, number, number, string, string][] = [
+			['<div>Router</div>', 0, 11, 'Router', '<Router>|</Router>', ],
+			['<div>MyAwesomeComponent</div>', 0, 23, 'MyAwesomeComponent', '<MyAwesomeComponent>|</MyAwesomeComponent>'],
+		];
+		testCases.forEach(([content, positionLine, positionChar, expectedAbbr, expectedExpansion]) => {
+			const document = TextDocument.create('test://test/test.jsx', 'jsx', 0, content);
+			const position = Position.create(positionLine, positionChar);
+			const completionList = doComplete(document, position, 'jsx', {
+				preferences: {},
+				showExpandedAbbreviation: 'always',
+				showAbbreviationSuggestions: false,
+				syntaxProfiles: {},
+				variables: {}
+			});
+
+			assert.strictEqual(completionList.items[0].label, expectedAbbr);
+			assert.strictEqual(completionList.items[0].documentation, expectedExpansion);
+		});
+	})
+
 	it('should not provide completions as they would noise when typing (css)', async () => {
 		await updateExtensionsPath(null);
 		const testCases: [string, number, number][] = [


### PR DESCRIPTION
#### fix https://github.com/microsoft/vscode/issues/89746

![image](https://user-images.githubusercontent.com/22636233/108606226-cbe59500-73f3-11eb-9896-0db90a6de44e.png)


/cc @rzhao271 @ramya-rao-a 