### PR TITLE
Fixes Issue 117154 - VScode Emmet missing HTML "hgroup" tag

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -7,6 +7,6 @@ export const htmlData = {
         "body", "head", "html",
         "address", "blockquote", "dd", "div", "section", "article", "aside", "header", "footer", "nav", "menu", "dl", "dt", "fieldset", "form", "frame", "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "iframe", "noframes", "object", "ol", "p", "ul", "applet", "center", "dir", "hr", "pre",
         "a", "abbr", "acronym", "area", "b", "base", "basefont", "bdo", "big", "br", "button", "caption", "cite", "code", "col", "colgroup", "del", "dfn", "em", "font", "i", "img", "input", "ins", "isindex", "kbd", "label", "legend", "li", "link", "map", "meta", "noscript", "optgroup", "option", "param", "q", "s", "samp", "script", "select", "small", "span", "strike", "strong", "style", "sub", "sup", "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "title", "tr", "tt", "u", "var",
-        "canvas", "main", "figure", "plaintext", "figcaption"
+        "canvas", "main", "figure", "plaintext", "figcaption", "hgroup"
     ]
 }

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -119,9 +119,6 @@ describe('Expand Abbreviations', () => {
 	// https://github.com/microsoft/vscode/issues/114923
 	testExpandWithCompletion('html', 'figcaption', '<figcaption>${0}</figcaption>');
 
-	// https://github.com/microsoft/vscode/issues/117154
-	testExpandWithCompletion('html', 'hgroup', '<hgroup>${0}</hgroup>');
-
 	// https://github.com/microsoft/vscode/issues/115623
 	testCountCompletions('html', 'html', 1);
 	testCountCompletions('html', 'body', 1);
@@ -146,6 +143,9 @@ describe('Expand Abbreviations', () => {
 	// `output.reverseAttributes` emmet option
 	testExpand('html', 'a.dropdown-item[href=#]{foo}', '<a href="#" class="dropdown-item">foo</a>', { "output.reverseAttributes": false });
 	testExpand('html', 'a.dropdown-item[href=#]{foo}', '<a class="dropdown-item" href="#">foo</a>', { "output.reverseAttributes": true });
+
+	// https://github.com/microsoft/vscode/issues/117154
+	testExpandWithCompletion('html', 'hgroup', '<hgroup>${0}</hgroup>');
 });
 
 describe('Wrap Abbreviations (basic)', () => {

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -119,6 +119,9 @@ describe('Expand Abbreviations', () => {
 	// https://github.com/microsoft/vscode/issues/114923
 	testExpandWithCompletion('html', 'figcaption', '<figcaption>${0}</figcaption>');
 
+	// https://github.com/microsoft/vscode/issues/117154
+	testExpandWithCompletion('html', 'hgroup', '<hgroup>${0}</hgroup>');
+
 	// https://github.com/microsoft/vscode/issues/115623
 	testCountCompletions('html', 'html', 1);
 	testCountCompletions('html', 'body', 1);


### PR DESCRIPTION
## Description 
This PR adds suggestion for the ```hgroup``` tag in vscode-emmet-helper.
Fixes [Issue #117154](https://github.com/microsoft/vscode/issues/117154).

