### PR TITLE
Fix casing

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -134,7 +134,7 @@ export function doComplete(document: TextDocument, position: Position, syntax: s
 		expandedAbbr.textEdit = TextEdit.replace(abbreviationRange, escapeNonTabStopDollar(addFinalTabStop(expandedText)));
 		expandedAbbr.documentation = replaceTabStopsWithCursors(expandedText);
 		expandedAbbr.insertTextFormat = InsertTextFormat.Snippet;
-		expandedAbbr.detail = l10n.t('Emmet abbreviation');
+		expandedAbbr.detail = l10n.t('Emmet Abbreviation');
 		expandedAbbr.label = abbreviation;
 		expandedAbbr.label += filter ? '|' + filter.replace(',', '|') : "";
 		completionItems = [expandedAbbr];

--- a/src/test/emmetHelper.test.ts
+++ b/src/test/emmetHelper.test.ts
@@ -1272,7 +1272,7 @@ describe('Test completions', () => {
 
 		assert.ok(completionList);
 		assert.strictEqual(completionList.items[0].kind, CompletionItemKind.Snippet);
-		assert.strictEqual(completionList.items[0].detail, 'Emmet abbreviation');
+		assert.strictEqual(completionList.items[0].detail, 'Emmet Abbreviation');
 	});
 
 	it('should not provide double completions for commonly used tags that are also snippets', async () => {


### PR DESCRIPTION
I don't remember why I changed the casing of the detail string from uppercase to lowercase--it should be uppercase still to match other snippets like "For-Each Loop", along with previous versions of the library.