### PR TITLE
fix: mark successive dots as noise and invalidate jinja syntax abbreviations 

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -523,7 +523,7 @@ export function isAbbreviationValid(syntax: string, abbreviation: string): boole
 	}
 	
 	// Fix for jinja syntax https://github.com/microsoft/vscode/issues/179422
-	if (/^({%|{#|{{)/.test(abbreviation)) {
+	if (/^{%|{#|{{/.test(abbreviation)) {
 		return false;
 	}
 	

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -566,7 +566,7 @@ function isExpandedTextNoise(syntax: string, abbreviation: string, expandedText:
 	}
 
 	// users might write successive dots '.' which shouldn't be treated as an abbreviation
-	const successiveDots = abbreviation.match(/^([.]+)$/);
+	const successiveDots = abbreviation.match(/^(\.{2,})$/);
 	if (successiveDots) {
 		return true;
 	}

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -565,7 +565,7 @@ function isExpandedTextNoise(syntax: string, abbreviation: string, expandedText:
 		return false;
 	}
 
-	// users might write successive dots '.' which shouldn't be treated as an abbreviation
+	// users might write successive dots '..', '...' which shouldn't be treated as an abbreviation
 	const successiveDots = abbreviation.match(/^(\.{2,})$/);
 	if (successiveDots) {
 		return true;

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -523,10 +523,8 @@ export function isAbbreviationValid(syntax: string, abbreviation: string): boole
 	}
 	
 	// Fix for jinja syntax https://github.com/microsoft/vscode/issues/179422
-	if (syntax === 'html') {
-		if (/^({%|{#|{{)/.test(abbreviation)) {
-		  return false;
-		}
+	if (/^({%|{#|{{)/.test(abbreviation)) {
+		return false;
 	}
 	
 	return (htmlAbbreviationStartRegex.test(abbreviation) && htmlAbbreviationRegex.test(abbreviation));

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -566,8 +566,7 @@ function isExpandedTextNoise(syntax: string, abbreviation: string, expandedText:
 	}
 
 	// users might write successive dots '..', '...' which shouldn't be treated as an abbreviation
-	const successiveDots = abbreviation.match(/^(\.{2,})$/);
-	if (successiveDots) {
+	if (/^\.{2,}$/.test(abbreviation)) {
 		return true;
 	}
 

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -521,6 +521,14 @@ export function isAbbreviationValid(syntax: string, abbreviation: string): boole
 	if (syntax === 'jsx') {
 		return (jsxAbbreviationStartRegex.test(abbreviation) && htmlAbbreviationRegex.test(abbreviation));
 	}
+	
+	// Fix for jinja syntax https://github.com/microsoft/vscode/issues/179422
+	if (syntax === 'html') {
+		if (/^({%|{#|{{)/.test(abbreviation)) {
+		  return false;
+		}
+	}
+	
 	return (htmlAbbreviationStartRegex.test(abbreviation) && htmlAbbreviationRegex.test(abbreviation));
 }
 
@@ -555,6 +563,12 @@ function isExpandedTextNoise(syntax: string, abbreviation: string, expandedText:
 	if (/[-,:]/.test(abbreviation) && !/--|::/.test(abbreviation) &&
 		!abbreviation.endsWith(':')) {
 		return false;
+	}
+
+	// users might write successive dots '.' which shouldn't be treated as an abbreviation
+	const successiveDots = abbreviation.match(/^([.]+)$/);
+	if (successiveDots) {
+		return true;
 	}
 
 	// Its common for users to type some text and end it with period, this should not be treated as an abbreviation

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -297,4 +297,5 @@ describe('Wrap Abbreviations (more advanced)', () => {
 	
 	// https://github.com/microsoft/vscode/issues/179422#issuecomment-1504099693
 	testCountCompletions('html', '..', 0);
+	testCountCompletions('html', '.', 1);
 });

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -134,14 +134,6 @@ describe('Expand Abbreviations', () => {
 	testCountCompletions('sass', 'bkco', 0);
 	testCountCompletions('sass', 'bgc', 1);
 
-	// https://github.com/microsoft/vscode/issues/179422
-	testCountCompletions('html', '{% if value is prime %}', 0);
-	testCountCompletions('html', '{# comment #}', 0);
-	testCountCompletions('html', '{{ value }}', 0);
-	
-	// https://github.com/microsoft/vscode/issues/179422#issuecomment-1504099693
-	testCountCompletions('html', '..', 0);
-
 	// https://github.com/microsoft/vscode/issues/115946
 	testExpandWithCompletion('html', '{test}*3', 'test\ntest\ntest');
 
@@ -297,4 +289,12 @@ describe('Wrap Abbreviations (more advanced)', () => {
 	// https://github.com/microsoft/vscode/issues/122231
 	testWrap('div', '<img src={`img/projects/${src}`} alt=\'\' />',
 		'<div><img src={`img/projects/${src}`} alt=\'\' /></div>', undefined, 'jsx');
+
+	// https://github.com/microsoft/vscode/issues/179422
+	testCountCompletions('html', '{% if value is prime %}', 0);
+	testCountCompletions('html', '{# comment #}', 0);
+	testCountCompletions('html', '{{ value }}', 0);
+	
+	// https://github.com/microsoft/vscode/issues/179422#issuecomment-1504099693
+	testCountCompletions('html', '..', 0);
 });

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -134,6 +134,14 @@ describe('Expand Abbreviations', () => {
 	testCountCompletions('sass', 'bkco', 0);
 	testCountCompletions('sass', 'bgc', 1);
 
+	// https://github.com/microsoft/vscode/issues/179422
+	testCountCompletions('html', '{% if value is prime %}', 0);
+	testCountCompletions('html', '{# comment #}', 0);
+	testCountCompletions('html', '{{ value }}', 0);
+	
+	// https://github.com/microsoft/vscode/issues/179422#issuecomment-1504099693
+	testCountCompletions('html', '..', 0);
+
 	// https://github.com/microsoft/vscode/issues/115946
 	testExpandWithCompletion('html', '{test}*3', 'test\ntest\ntest');
 

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -297,5 +297,6 @@ describe('Wrap Abbreviations (more advanced)', () => {
 	
 	// https://github.com/microsoft/vscode/issues/179422#issuecomment-1504099693
 	testCountCompletions('html', '..', 0);
-	testCountCompletions('html', '.', 1);
+	testExpandWithCompletion('html', '.', '<div class="${1}">${0}</div>');
+
 });


### PR DESCRIPTION
Hi, this PR should fix https://github.com/microsoft/vscode/issues/179422
let me know if it could be done in any better way