### PR TITLE
fix: merge attributes before passing them upstream

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -674,7 +674,7 @@ export function getExpandOptions(syntax: string, emmetConfig?: VSCodeEmmetConfig
 	};
 
 	// These options come from user prefs in the vscode repo
-	const userPreferenceOptions: Partial<Options> = {
+	let userPreferenceOptions: Partial<Options> = {
 		// inlineElements: string[],
 		// 'output.indent': string,
 		// 'output.baseIndent': string,
@@ -712,9 +712,34 @@ export function getExpandOptions(syntax: string, emmetConfig?: VSCodeEmmetConfig
 		'stylesheet.unitAliases': unitAliases,
 		// 'stylesheet.json': boolean,
 		// 'stylesheet.jsonDoubleQuotes': boolean,
-		'stylesheet.fuzzySearchMinScore': preferences['css.fuzzySearchMinScore'],
-		'markup.attributes': profile['markup.attributes'],
-		'markup.valuePrefix': profile['markup.valuePrefix'],
+		'stylesheet.fuzzySearchMinScore': preferences['css.fuzzySearchMinScore']
+	};
+
+	if (syntax === 'jsx') {
+		// Ref https://github.com/emmetio/emmet/blob/master/src/config.ts#L391
+		const defaultMarkupAttributeOptions = {
+			'class': 'className',
+			'class*': 'styleName',
+			'for': 'htmlFor'
+		};
+		const defaultMarkupValuePrefixOptions = {
+			'class*': 'styles'
+		};
+
+		// Rather than trying to merge these specific options upstream,
+		// we can merge them here before passing them upstream.
+		if (profile['markup.attributes']) {
+			userPreferenceOptions['markup.attributes'] = {
+				...defaultMarkupAttributeOptions,
+				...profile['markup.attributes']
+			};
+		}
+		if (profile['markup.valuePrefix']) {
+			userPreferenceOptions['markup.valuePrefix'] = {
+				...defaultMarkupValuePrefixOptions,
+				...profile['markup.valuePrefix']
+			};
+		}
 	}
 
 	const combinedOptions: any = {};

--- a/src/test/emmetHelper.test.ts
+++ b/src/test/emmetHelper.test.ts
@@ -1314,19 +1314,66 @@ describe('Test completions', () => {
 		assert.strictEqual(completionList.items[0].label, 'abbr');
 	});
 
-	it('should complete JSX tags with custom syntaxProfile', async () => {
+	it('should complete JSX tags with attribute overrides', async () => {
 		await updateExtensionsPath([]);
-		const expanded = expandAbbreviation('..test', {
-			syntax: 'jsx',
-			options: {
-				"markup.attributes": {
-					"class*": "className"
-				},
-				"markup.valuePrefix": {
-					"class*": "myPrefixHere"
+		const options = {
+			'syntaxProfiles': {
+				'jsx': {
+					'markup.attributes': {
+						'class': 'classPlainName',
+						'class*': 'classStarName'
+					},
+					'markup.valuePrefix': {
+						'class': 'classPlainPrefix',
+						'class*': 'classStarPrefix'
+					}
 				}
 			}
-		});
-		assert.strictEqual(expanded, '<div className={myPrefixHere.test}></div>');
+		};
+		const expanded = expandAbbreviation('..test', getExpandOptions('jsx', options));
+		assert.strictEqual(expanded, '<div classStarName={classStarPrefix.test}>${0}</div>');
+		const expandedSecond = expandAbbreviation('.test', getExpandOptions('jsx', options));
+		assert.strictEqual(expandedSecond, '<div classPlainName={classPlainPrefix.test}>${0}</div>');
+	});
+
+	it('should complete JSX tags with empty string value prefix', async () => {
+		await updateExtensionsPath([]);
+		const options = {
+			'syntaxProfiles': {
+				'jsx': {
+					'markup.attributes': {
+						'class': 'classPlainName',
+						'class*': 'classStarName'
+					},
+					'markup.valuePrefix': {
+						'class': '',
+						'class*': ''
+					}
+				}
+			}
+		};
+		const expanded = expandAbbreviation('..test', getExpandOptions('jsx', options));
+		assert.strictEqual(expanded, '<div classStarName="test">${0}</div>');
+		const expandedSecond = expandAbbreviation('.test', getExpandOptions('jsx', options));
+		assert.strictEqual(expandedSecond, '<div classPlainName="test">${0}</div>');
+	});
+
+	it('should complete JSX tags with partial attribute overrides', async () => {
+		const options = {
+			'syntaxProfiles': {
+				'jsx': {
+					'markup.attributes': {
+						'class*': 'classStarName'
+					},
+					'markup.valuePrefix': {
+						'class': 'classPlainPrefix',
+					}
+				}
+			}
+		};
+		const expanded = expandAbbreviation('.test', getExpandOptions('jsx', options));
+		assert.strictEqual(expanded, '<div className={classPlainPrefix.test}>${0}</div>');
+		const expandedSecond = expandAbbreviation('..test', getExpandOptions('jsx', options));
+		assert.strictEqual(expandedSecond, '<div classStarName={styles.test}>${0}</div>');
 	});
 })

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -196,6 +196,10 @@ describe('Expand Abbreviations', () => {
 		assert.ok(!expandedRes.includes('X-UA-Compatible'));
 	});
 
+	// https://github.com/microsoft/vscode/issues/180689
+	testExpandWithCompletion('jsx', '.bar', '<div className="bar">${0}</div>', { 'syntaxProfiles': { 'jsx': { 'jsx.enabled': true }}});
+	testExpandWithCompletion('jsx', '..bar', '<div styleName={styles.bar}>${0}</div>', { 'syntaxProfiles': { 'jsx': { 'jsx.enabled': true }}});
+
 	// https://github.com/microsoft/vscode/issues/137240
 	// testExpandWithCompletion('css', 'dn!important', 'display: none !important;');
 
@@ -294,7 +298,7 @@ describe('Wrap Abbreviations (more advanced)', () => {
 	testCountCompletions('html', '{% if value is prime %}', 0);
 	testCountCompletions('html', '{# comment #}', 0);
 	testCountCompletions('html', '{{ value }}', 0);
-	
+
 	// https://github.com/microsoft/vscode/issues/179422#issuecomment-1504099693
 	testCountCompletions('html', '..', 0);
 	testExpandWithCompletion('html', '.', '<div class="${1}">${0}</div>');


### PR DESCRIPTION
Ref downstream PR https://github.com/microsoft/vscode/pull/185607

Emmet added some new object properties, but the upstream merging algorithm makes it so that if a user only defines some keys to customize, the other keys within that same property are erased.

This PR works around the issue by merging the properties with the upstream defaults, and then passing in that entire object upstream so that the default object gets overridden with the larger object.