### PR TITLE
feat: add vue and svelte to the known languages list

### DIFF
--- a/src/configCompat.ts
+++ b/src/configCompat.ts
@@ -45,6 +45,6 @@ export function parseSnippets(snippets: SnippetsMap): SnippetsMap {
  * List of all known syntaxes
  */
 export const syntaxes = {
-    markup: ['html', 'xml', 'xsl', 'jsx', 'js', 'pug', 'slim', 'haml'],
+    markup: ['html', 'xml', 'xsl', 'jsx', 'js', 'pug', 'slim', 'haml', 'vue', 'svelte'],
     stylesheet: ['css', 'sass', 'scss', 'less', 'sss', 'stylus']
 };


### PR DESCRIPTION
This PR adds `vue` and `svelte` to the known languages list ([source](https://github.com/emmetio/emmet/blob/master/src/config.ts#L298C71-L298C87))