### PR TITLE
Add missing HTML tags to emmet

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -7,6 +7,6 @@ export const htmlData = {
         "body", "head", "html",
         "address", "blockquote", "dd", "div", "section", "article", "aside", "header", "footer", "nav", "menu", "dl", "dt", "fieldset", "form", "frame", "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "iframe", "noframes", "object", "ol", "p", "ul", "applet", "center", "dir", "hr", "pre",
         "a", "abbr", "acronym", "area", "b", "base", "basefont", "bdo", "big", "br", "button", "caption", "cite", "code", "col", "colgroup", "del", "dfn", "em", "font", "i", "img", "input", "ins", "isindex", "kbd", "label", "legend", "li", "link", "map", "meta", "noscript", "optgroup", "option", "param", "q", "s", "samp", "script", "select", "small", "span", "strike", "strong", "style", "sub", "sup", "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "title", "tr", "tt", "u", "var",
-        "canvas", "main", "figure", "plaintext", "figcaption", "hgroup", "details", "summary"
+        "canvas", "main", "figure", "plaintext", "figcaption", "hgroup", "details", "summary", "audio", "bdi", "data", "datalist", "dialog", "embed", "mark", "math", "meter", "output", "picture", "portal", "progress", "rp", "rt", "ruby", "search", "slot", "source", "template", "time", "track", "video", "wbr"
     ]
 }

--- a/src/test/emmetHelper.test.ts
+++ b/src/test/emmetHelper.test.ts
@@ -88,6 +88,7 @@ describe('Validate Abbreviations', () => {
 			'ul>li',
 			'ul',
 			'h1',
+			'picture>source',
 			'ul>li*3',
 			'(ul>li)+div',
 			'.hello',

--- a/src/test/expand.test.ts
+++ b/src/test/expand.test.ts
@@ -211,6 +211,12 @@ describe('Expand Abbreviations', () => {
 	testExpandWithCompletion('css', '!imp', '!important');
 	testCountCompletions('css', '!importante', 0);
 
+	
+	testExpandWithCompletion('html', 'vid', '<video src="${1}">${0}</video>');
+	testExpandWithCompletion('html', 'dlg', '<dialog>${0}</dialog>');
+	testExpandWithCompletion('html', 'datal', '<datalist>${0}</datalist>');
+	testExpandWithCompletion('html', 'prog', '<progress>${0}</progress>');
+
 	// escaped dollar signs should not change after going through Emmet expansion only
 	// VS Code automatically removes the backslashes after the expansion
 	testExpand('html', 'span{\\$5}', '<span>\\$5</span>');


### PR DESCRIPTION
Adds the following missing HTML tags:

`<audio>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
`<bdi>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi
`<data>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
`<datalist>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist
`<dialog>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
`<embed>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed
`<mark>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
`<math>` https://developer.mozilla.org/en-US/docs/Web/MathML/Element/math
`<meter>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter
`<output>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output
`<picture>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
`<portal>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/portal
`<progress>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
`<rp>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp
`<rt>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt
`<ruby>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
`<search>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
`<slot>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
`<source>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
`<template>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template
`<time>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
`<track>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
`<video>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
`<wbr>` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
