### PR TITLE
Make `emmet.syntaxProfiles` configuration item to support custom language Id

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -23,8 +23,11 @@ import { parseSnippets, SnippetsMap, syntaxes } from './configCompat';
 export { FileService, FileType, FileStat };
 
 let l10n: { t: (message: string) => string };
+let getProfileOfCurrentLanguageId = (profilesConfig: any) => null;
 try {
-	l10n = require('vscode').l10n;
+	var vscode = require('vscode');
+	l10n = vscode.l10n;
+	getProfileOfCurrentLanguageId = (profilesConfig: any) => profilesConfig[vscode.window.activeTextEditor.document.languageId];
 } catch {
 	// Fallback to the identity function.
 	l10n = {
@@ -851,7 +854,7 @@ function getProfile(syntax: string, profilesFromSettings: any): any {
 	}
 	const profilesConfig = Object.assign({}, profilesFromFile, profilesFromSettings);
 
-	const options = profilesConfig[syntax];
+	const options = getProfileOfCurrentLanguageId(profilesConfig) || profilesConfig[syntax];
 	if (!options || typeof options === 'string') {
 		if (options === 'xhtml') {
 			return {

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -14,6 +14,7 @@ import { FileService, FileStat, FileType, isAbsolutePath, joinPath } from './fil
 
 import expand, { Config, extract, ExtractOptions, MarkupAbbreviation, Options, parseMarkup, parseStylesheet, resolveConfig, stringifyMarkup, stringifyStylesheet, StylesheetAbbreviation, SyntaxType, UserConfig } from 'emmet';
 import { parseSnippets, SnippetsMap, syntaxes } from './configCompat';
+import * as vscode from 'vscode';
 
 // /* workaround for webpack issue: https://github.com/webpack/webpack/issues/5756
 //  @emmetio/extract-abbreviation has a cjs that uses a default export
@@ -851,7 +852,9 @@ function getProfile(syntax: string, profilesFromSettings: any): any {
 	}
 	const profilesConfig = Object.assign({}, profilesFromFile, profilesFromSettings);
 
-	const options = profilesConfig[syntax];
+	const activeEditor = vscode.window.activeTextEditor;
+
+	const options = activeEditor && profilesConfig[activeEditor.document.languageId] || profilesConfig[syntax];
 	if (!options || typeof options === 'string') {
 		if (options === 'xhtml') {
 			return {

--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -23,11 +23,8 @@ import { parseSnippets, SnippetsMap, syntaxes } from './configCompat';
 export { FileService, FileType, FileStat };
 
 let l10n: { t: (message: string) => string };
-let getProfileOfCurrentLanguageId = (profilesConfig: any) => null;
 try {
-	var vscode = require('vscode');
-	l10n = vscode.l10n;
-	getProfileOfCurrentLanguageId = (profilesConfig: any) => profilesConfig[vscode.window.activeTextEditor.document.languageId];
+	l10n = require('vscode').l10n;
 } catch {
 	// Fallback to the identity function.
 	l10n = {
@@ -854,7 +851,7 @@ function getProfile(syntax: string, profilesFromSettings: any): any {
 	}
 	const profilesConfig = Object.assign({}, profilesFromFile, profilesFromSettings);
 
-	const options = getProfileOfCurrentLanguageId(profilesConfig) || profilesConfig[syntax];
+	const options = profilesConfig[syntax];
 	if (!options || typeof options === 'string') {
 		if (options === 'xhtml') {
 			return {


### PR DESCRIPTION
Make `emmet.syntaxProfiles` configuration item to support custom language Id. For example:

Previously, if you wanted to modify the final output of Markdown Emmet, you had to configure it like this:

```JSON
  "emmet.includeLanguages": { "markdown": "html" },
  "emmet.syntaxProfiles": {
    "html": { // modified the html configuration
      "tag_nl": false,
      "tag_nl_leaf": false
    }
  },
```

Since it modifies the `html` configuration, the output for the HTML language will also be affected. With this commit, it is now supported:

```JSON
  "emmet.includeLanguages": { "markdown": "html" },
  "emmet.syntaxProfiles": {
    "markdown": { // only modified the markdown configuration
      "tag_nl": false,
      "tag_nl_leaf": false
    }
  },
```

This way, only the `markdown` configuration is modified, and the HTML language configuration will not be affected.