### PR TITLE
Delay importing the util package to fix browser compatibility

### DIFF
--- a/src/emmetHelper.ts
+++ b/src/emmetHelper.ts
@@ -5,7 +5,7 @@
 
 
 import * as JSONC from 'jsonc-parser';
-import { TextDecoder } from 'util';
+import type { TextDecoder } from 'util';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CompletionItem, CompletionItemKind, CompletionList, InsertTextFormat, Position, Range, TextEdit } from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
@@ -1035,7 +1035,7 @@ export async function updateExtensionsPath(emmetExtensionsPathSetting: string[],
 		if (typeof (globalThis as any).TextDecoder === 'function') {
 			decoder = new (globalThis as any).TextDecoder() as TextDecoder;
 		} else {
-			decoder = new TextDecoder();
+			decoder = new (require('util').TextDecoder)() as TextDecoder;
 		}
 
 		// the only errors we want to throw here are JSON parse errors


### PR DESCRIPTION
This PR fixes vuejs/repl#258

https://github.com/microsoft/vscode-emmet-helper/blob/a04604f5ec5213b3427c0fbc0f0c0cd1ba2ea7fc/src/emmetHelper.ts#L1038

This line uses the TextDecoder imported from the util package as a fallback for the Node.js environment. However, since the util package is imported globally, it always breaks browser execution.

The fix is to lazily import the util package only within the fallback branch for the Node.js environment.

Related to https://github.com/browserify/node-util/issues/77.    